### PR TITLE
Improve module description

### DIFF
--- a/src/de.jensd.fx.glyphs.materialdesignicons/module-info.java
+++ b/src/de.jensd.fx.glyphs.materialdesignicons/module-info.java
@@ -1,10 +1,8 @@
 module de.jensd.fx.glyphs.materialdesignicons {
     exports de.jensd.fx.glyphs.materialdesignicons;
-    exports de.jensd.fx.glyphs.materialdesignicons.demo;
     exports de.jensd.fx.glyphs.materialdesignicons.utils;
     requires de.jensd.fx.glyphs.commons;
-    requires javafx.base;
     requires javafx.controls;
     requires javafx.fxml;
-    requires javafx.graphics;
+    requires transitive javafx.graphics;
 }

--- a/src/de.jensd.fx.glyphs.materialdesignicons/module-info.java
+++ b/src/de.jensd.fx.glyphs.materialdesignicons/module-info.java
@@ -4,5 +4,5 @@ module de.jensd.fx.glyphs.materialdesignicons {
     requires de.jensd.fx.glyphs.commons;
     requires javafx.controls;
     requires javafx.fxml;
-    requires transitive javafx.graphics;
+    requires javafx.graphics;
 }


### PR DESCRIPTION
Improves the module description by not exposing the demo (no library user would normally want to use the demo directly).

I suggest to also check if the javafx require statements should be transitive: https://blog.codefx.org/java/implied-readability/ (and https://stackoverflow.com/questions/53548096/package-com-example-reads-package-javafx-beans-from-both-javafx-base-and/53550028 which lead me to it).